### PR TITLE
Added syntax highlighting for multi line comments 

### DIFF
--- a/syntax/elsa.vim
+++ b/syntax/elsa.vim
@@ -16,6 +16,13 @@ setlocal commentstring=--%s
 syntax match elsaComment "\v--.*$"
 highlight link elsaComment Comment
 
+" Multi-line comments
+syntax cluster elsaCommentContained contains=elsaComment,elsaCommentEnd
+syntax region elsaComment start="{-" end="-}" contains=@elsaCommentContained keepend
+syntax match elsaCommentEnd "-}" contained
+highlight link elsaComment Comment
+highlight link elsaCommentEnd Comment
+
 " Operators
 syntax match elsaOperator "\v\="
 syntax match elsaOperator "\v\=[abd*~]\>"

--- a/syntax/elsa.vim
+++ b/syntax/elsa.vim
@@ -17,11 +17,8 @@ syntax match elsaComment "\v--.*$"
 highlight link elsaComment Comment
 
 " Multi-line comments
-syntax cluster elsaCommentContained contains=elsaComment,elsaCommentEnd
-syntax region elsaComment start="{-" end="-}" contains=@elsaCommentContained keepend
-syntax match elsaCommentEnd "-}" contained
-highlight link elsaComment Comment
-highlight link elsaCommentEnd Comment
+syntax region elsaMultiLineComment start="{-" end="-}" keepend
+highlight link elsaMultiLineComment Comment
 
 " Operators
 syntax match elsaOperator "\v\="


### PR DESCRIPTION
Elsa language supports multi-line comments using {- and -}, but this Vim plugin didn't support the syntax highlighting for it, so I added multi-line comment color handling. It is the same color as single-line comment syntax highlighting.

Here is an example of it working.
<img width="786" alt="Screenshot 2025-06-13 at 10 25 54 PM" src="https://github.com/user-attachments/assets/72d68fa0-dca7-451c-b7a6-489990fe7bc7" />